### PR TITLE
添加x86架构支持

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,18 +10,20 @@ android {
         versionCode 1
         versionName "1.0"
         applicationId "ctrip.wireless.android.crn"
-
-        ndk {
-            abiFilters 'armeabi-v7a'
-        }
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            ndk {
+                abiFilters 'armeabi-v7a'
+            }
         }
         debug {
             jniDebuggable true
+            ndk {
+                abiFilters 'armeabi-v7a', 'x86'
+            }
         }
     }
 }


### PR DESCRIPTION
希望crn-cli 模块的模板  安卓app的gradle 开发模式能添加x86架构，能在模拟器上运行